### PR TITLE
Added admin enabling feature for an admin account, use route /enable_…

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -106,6 +106,24 @@ class ActivitiesController < ApplicationController
     render :text => "abort activity"
   end
 
+  def enable_admin
+    puts "enabling admin for current user"
+    puts params[:code].to_s	
+    @adminCode = '9128'
+    puts @adminCode.eql?(params[:code])
+    if params[:code].eql?(@adminCode)
+	if User.exists?(user_name: "Admin")
+		puts "Admin Account exists, setting admin privleges"
+		@adminUser = User.find_by(user_name: "Admin")
+		@adminUser.update(is_admin: true)
+	else
+		puts "No admin account"
+	end
+	render :text => "admin enabled"
+    else
+    	render :text => "Wrong Code" 
+    end
+  end
   # def set_activity_id
   #   puts "activity_id"
   #   puts params[:activity_id]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
 
   get '/abort_activity/:id' => 'activities#abort_activity', as: :abort_activity
 
+  # secret admin code to set user as an admin
+  get '/enable_admin/:code' => 'activities#enable_admin' 
+
 
 
   # Example of named route that can be invoked with purchase_url(id: product.id)

--- a/db/migrate/20160425213227_add_is_admin_to_user.rb
+++ b/db/migrate/20160425213227_add_is_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddIsAdminToUser < ActiveRecord::Migration
+  def change
+	add_column :users, :is_admin, :boolean, :default => false   
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160419202013) do
+ActiveRecord::Schema.define(version: 20160425213227) do
 
   create_table "activities", force: :cascade do |t|
     t.string   "title"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20160419202013) do
     t.integer  "level",                  default: 1
     t.text     "experimental_condition", default: "Initial condition"
     t.boolean  "is_active",              default: true
+    t.boolean  "is_admin",               default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
Added admin enabling feature for an admin account, use route /enable_admin/:code and the correct code will enable 'Admin' user admin access for the experiment
